### PR TITLE
タグ一覧ページを作成

### DIFF
--- a/myblog/urls.py
+++ b/myblog/urls.py
@@ -4,5 +4,7 @@ from . import views
 app_name = 'myblog'
 urlpatterns = [
     path('', views.ArticleListView.as_view(), name='Index'),
-    path('detail/<pk>/', views.ArticleDetailView.as_view(), name='Detail')
+    path('detail/<pk>/', views.ArticleDetailView.as_view(), name='Detail'),
+    path('tag', views.TagListView.as_view(), name='TagIndex'),
+    path('article/tag/<pk>/', views.ArticleByTagListView.as_view(), name='ArticleByTagIndex')
 ]

--- a/myblog/views.py
+++ b/myblog/views.py
@@ -1,5 +1,6 @@
 from django.views import generic
 from .models import Article
+from .models import Tag
 
 class ArticleListView(generic.ListView):
     model = Article
@@ -19,4 +20,30 @@ class ArticleDetailView(generic.DetailView):
         article = context.get("object")
         article.views += 1
         article.save()
+        return context
+
+class TagListView(generic.ListView):
+    model = Tag
+    template_name = 'tag_index.html'
+
+    def get_queryset(self):
+        tag = Tag.objects.all().order_by('-name')
+        return tag
+
+class ArticleByTagListView(generic.ListView):
+    model = Article
+    template_name = 'article_by_tag_index.html'
+
+
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        tag_id = self.kwargs.get('pk')
+        article_list = Article.objects.filter(tags__in=[tag_id]).order_by('-created_at')
+        tag = Tag.objects.filter(id=tag_id)
+        tag_name = tag[0].name if tag and tag[0] else ''
+        context.update({
+            'article_list': article_list,
+            'tag_name': tag_name
+        })
         return context

--- a/templates/myblog/article_by_tag_index.html
+++ b/templates/myblog/article_by_tag_index.html
@@ -2,11 +2,10 @@
 
 {% block title %}WHITE LEAF{% endblock %}
 
-<!-- body --> 
+<!-- body -->
 {% block contents %}
-    <h4 class="ml-2 mt-2">記事一覧</h4>
+    <h4 class="ml-2 mt-2">【{{ tag_name }}】記事一覧</h4>
         {% for article in article_list %}
-
             <div class="card m-2">
                 <div class="card-body" >
                     <div class="clearfix">
@@ -41,7 +40,7 @@
 
 {% endblock %}
 
-<!-- サイドバー --> 
+<!-- サイドバー -->
 {% block sidebar %}
     <div>
         運営者<br>

--- a/templates/myblog/detail.html
+++ b/templates/myblog/detail.html
@@ -13,7 +13,7 @@
         <div class="clearfix mb-2">
             <div class="float-right">
                 {% for tag in object.tags.all %}
-                    <a class="tag" href="#">
+                    <a class="tag" href="{% url 'myblog:ArticleByTagIndex' tag.id %}">
                         <i class="fas fa-tag"></i>
                         {{ tag.name }}
                     </a>

--- a/templates/myblog/tag_index.html
+++ b/templates/myblog/tag_index.html
@@ -2,46 +2,28 @@
 
 {% block title %}WHITE LEAF{% endblock %}
 
-<!-- body --> 
+<!-- body -->
 {% block contents %}
-    <h4 class="ml-2 mt-2">記事一覧</h4>
-        {% for article in article_list %}
+    <h4 class="ml-2 mt-2">タグ一覧</h4>
+        {% for tag in tag_list %}
 
             <div class="card m-2">
                 <div class="card-body" >
-                    <div class="clearfix">
-                        <div class="float-right">
-                            {% for tag in article.tags.all %}
-                                <a class="tag" href="{% url 'myblog:ArticleByTagIndex' tag.id %}">
-                                    <i class="fas fa-tag"></i>
-                                    {{ tag.name }}
-                                </a>
-                            {% endfor %}
-                        </div>
-                    </div>
-                    <a href="{% url 'myblog:Detail' article.id %}">
+                    <a href="{% url 'myblog:ArticleByTagIndex' tag.id %}">
                         <h5 class="card-title">
-                            <i class="far fa-newspaper"></i>
-                            {{ article.title }}
+                            {{ tag.name }}
                         </h5>
                     </a>
-                    <p class="card-text text-right">
-                        <i class="far fa-clock"></i>
-                        {{ article.created_at }}
-                        &nbsp;
-                        <i class="far fa-eye"></i>
-                        {{ article.views }}
-                    </p>
                 </div>
             </div>
 
         {% empty %}
-            <p>ブログがありません…</p>
+            <p>タグがありません…</p>
         {% endfor %}
 
 {% endblock %}
 
-<!-- サイドバー --> 
+<!-- サイドバー -->
 {% block sidebar %}
     <div>
         運営者<br>


### PR DESCRIPTION
## 作る画面
- Tag一覧ページ
    - path('tag', views.TagListView.as_view(), name='TagIndex')
- Tag別記事一覧ページ
    - path('artile/tag/<pk>/',views.ArticleByTagView.as_view(), name='ArticleByTagIndex' )
## 編集する画面
- base.htmlにヘッダーを追加
- Topへのリンク
- Tag一覧ページのリンク

## 処理
- Tag一覧ページ
    - Tagに登録されているものを全て表示する
    - name順
    - Tag別記事一覧ページにリンクする
- Tag別記事一覧ページ
    - Tagが紐づいている記事をcreated_at降順
    - Tag詳細画面へのリンク